### PR TITLE
Oversample fix

### DIFF
--- a/comparisons/default/solver/params.yaml
+++ b/comparisons/default/solver/params.yaml
@@ -20,7 +20,7 @@ source_params:
 ft_params:
   dt: 0.001
   N: 1200
-  oversample_rate: 8
+  extension_factor: 8
 
 seismogram_locations:
   - [500.0, 500.0]

--- a/comparisons/f8/solver/params.yaml
+++ b/comparisons/f8/solver/params.yaml
@@ -18,9 +18,9 @@ source_params:
   fc: 0
 
 ft_params:
-  dt: 2.5e-4
-  N: 10000
-  oversample_rate: 8
+  dt: 0.001
+  N: 3000
+  extension_factor: 8
 
 seismogram_locations:
   - [500.0, 500.0]

--- a/comparisons/set5_lofreq/solver/params.yaml
+++ b/comparisons/set5_lofreq/solver/params.yaml
@@ -18,9 +18,9 @@ source_params:
   fc: 1
 
 ft_params:
-  dt: 0.003
-  N: 1000
-  oversample_rate: 8
+  dt: 0.001
+  N: 3000
+  extension_factor: 8
 
 seismogram_locations:
   - [500.0, 500.0]

--- a/src/cosserat_solver/read_yaml.py
+++ b/src/cosserat_solver/read_yaml.py
@@ -36,7 +36,7 @@ def read(file_path: str):
         A dictionary containing the parameters for the Fourier transform. It should contain the following keys:
         - 'dt': The time step size for the output trace.
         - 'N': The number of time samples for the output trace.
-        - 'oversample_rate': An integer specifying the oversampling rate for internal frequency sampling.
+        - 'extension_factor': An integer specifying the factor for extending the window.
 
     digits_precision: int
         The number of digits of precision for intermediate mpmath calculations.

--- a/src/cosserat_solver/trace_generator.py
+++ b/src/cosserat_solver/trace_generator.py
@@ -44,7 +44,7 @@ def generate_trace(
         A dictionary containing the parameters for the Fourier transform. It should contain the following keys:
         - 'dt': The time step size for the output trace.
         - 'N': The number of time samples for the output trace.
-        - 'oversample_rate': An integer specifying the oversampling rate for internal frequency sampling.
+        - 'extension_factor': An integer specifying the factor for extending the window.
     digits_precision: int
         The number of digits of precision for intermediate mpmath calculations.
     output_dir: str

--- a/tests/test_python/test_fourier.py
+++ b/tests/test_python/test_fourier.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from scipy import integrate
 
 from cosserat_solver.fourier import cont_ifft
 
@@ -103,13 +102,7 @@ def raised_cosine_pair(T=1.0, t0=0.0):
                 # Limit as ω->0
                 result[i] = 1.0 * exp_shift[i]
             elif abs((w * T) ** 2 - np.pi**2) < eps:
-                # Pole at ω = π/T, compute via numerical integration
-
-                def integrand(t): # noqa: B023
-                    return f(t) * np.cos(w * t)
-
-                val, _ = integrate.quad(integrand, t0 - 2 * T, t0 + 2 * T)
-                result[i] = val * exp_shift[i]
+                result[i] = np.nan
             else:
                 # General formula: (π/T)² * sin(ωT) / (ωT * ((π/T)² - ω²))
                 pi_over_T = np.pi / T


### PR DESCRIPTION
Change the "oversample_rate" parameter to "extension_factor" (which extends the window intermediately to avoid wraparound effects) and "refinement_factor" (which computes the trace using a dt finer that that which is actually output). This eliminates the pre-wavefront arrival wraparound oscillations. Also, replaces the exponential decay tests with raised cosine pulses, resolving #3 